### PR TITLE
Add Patreon OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ npm install
 # NETWORK=base-sepolia
 # ADDRESS=0xYOUR_WALLET_ADDRESS
 # PORT=3001
+# PATREON_CLIENT_ID=your_patreon_client_id
+# PATREON_CLIENT_SECRET=your_patreon_client_secret
+# PATREON_REDIRECT_URI=http://localhost:3001/api/auth/patreon/callback
 
 npm run dev
 ```
@@ -74,6 +77,7 @@ npm run dev
 
 4. **Play the game:**
    - Open http://localhost:5173
+   - (Optional) Click "LOGIN WITH PATREON" to fetch your profile
    - Click "INSERT COIN" to pay $0.001 USDC
    - Or click "DEPOSIT $1" to load 1000 credits
    - Press SPACE or click to fly!

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npm install
 # PATREON_CLIENT_ID=your_patreon_client_id
 # PATREON_CLIENT_SECRET=your_patreon_client_secret
 # PATREON_REDIRECT_URI=http://localhost:3001/api/auth/patreon/callback
+# PATREON_USER_AGENT=Flappy x402 - Game Server
 
 npm run dev
 ```

--- a/client/src/components/GameMenu.tsx
+++ b/client/src/components/GameMenu.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import type { PaymentStatus } from "../services/x402Client";
 import { WalletConnect } from "./WalletConnect";
+import { PatreonLogin } from "./PatreonLogin";
+import { PlayerInfo } from "./PlayerInfo";
 import { useWallet } from "../contexts/WalletContext";
 
 interface GameMenuProps {
@@ -49,8 +51,9 @@ export function GameMenu({
 
         {/* Wallet Connection Status - only show if not in dev mode */}
         {!devMode && (
-          <div className="mb-8">
+          <div className="mb-8 space-y-4">
             <WalletConnect />
+            <PatreonLogin />
           </div>
         )}
 
@@ -205,7 +208,7 @@ export function GameMenu({
 
         {/* Player Info */}
         <div className="absolute top-8 left-8">
-          <div className="text-cyan-400 pixel-font-xs"></div>
+          <PlayerInfo />
         </div>
       </div>
 

--- a/client/src/components/PatreonLogin.tsx
+++ b/client/src/components/PatreonLogin.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { usePatreon } from '../contexts/PatreonContext';
+
+export function PatreonLogin() {
+  const { user, login, logout } = usePatreon();
+
+  if (user) {
+    return (
+      <div className="text-center">
+        <div className="inline-flex items-center gap-3 bg-black/50 px-4 py-2 rounded border border-green-400/50">
+          <span className="text-green-400 pixel-font-xs">PATREON</span>
+          <span className="text-cyan-400 pixel-font">{user.data.attributes.full_name}</span>
+          <button onClick={logout} className="text-red-400 hover:text-red-300 pixel-font-xs underline">LOGOUT</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center">
+      <button
+        onClick={login}
+        className="arcade-button px-6 py-3 text-white"
+      >
+        LOGIN WITH PATREON
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/PlayerInfo.tsx
+++ b/client/src/components/PlayerInfo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { usePatreon } from '../contexts/PatreonContext';
+
+export function PlayerInfo() {
+  const { user } = usePatreon();
+  if (!user) return null;
+  return (
+    <div className="text-cyan-400 pixel-font-xs">
+      {user.data.attributes.full_name}
+    </div>
+  );
+}

--- a/client/src/contexts/PatreonContext.tsx
+++ b/client/src/contexts/PatreonContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState } from 'react';
+import { loginWithPatreon, PatreonAuthResult } from '../services/patreonAuth';
+
+interface PatreonContextType {
+  user: any | null;
+  token: PatreonAuthResult['token'] | null;
+  login: () => Promise<void>;
+  logout: () => void;
+}
+
+const PatreonContext = createContext<PatreonContextType | undefined>(undefined);
+
+export function PatreonProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<any | null>(null);
+  const [token, setToken] = useState<PatreonAuthResult['token'] | null>(null);
+
+  const login = async () => {
+    const result = await loginWithPatreon();
+    setUser(result.user);
+    setToken(result.token);
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+  };
+
+  return (
+    <PatreonContext.Provider value={{ user, token, login, logout }}>
+      {children}
+    </PatreonContext.Provider>
+  );
+}
+
+export function usePatreon() {
+  const ctx = useContext(PatreonContext);
+  if (!ctx) throw new Error('usePatreon must be used within PatreonProvider');
+  return ctx;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import { WalletProvider } from './contexts/WalletContext.tsx'
+import { PatreonProvider } from './contexts/PatreonContext.tsx'
 import './index.css'
 
 // Show setup instructions in console
@@ -43,7 +44,9 @@ Need help? Check the README.md
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <WalletProvider>
-      <App />
+      <PatreonProvider>
+        <App />
+      </PatreonProvider>
     </WalletProvider>
   </StrictMode>,
 )

--- a/client/src/services/patreonAuth.ts
+++ b/client/src/services/patreonAuth.ts
@@ -1,0 +1,54 @@
+export interface PatreonTokenData {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+}
+
+export interface PatreonAuthResult {
+  token: PatreonTokenData;
+  user: any;
+}
+
+/**
+ * Open a popup window to begin Patreon OAuth login. Resolves with token
+ * and user info when authentication completes.
+ */
+export function loginWithPatreon(): Promise<PatreonAuthResult> {
+  const width = 600;
+  const height = 700;
+  const left = window.screenX + (window.outerWidth - width) / 2;
+  const top = window.screenY + (window.outerHeight - height) / 2;
+  const popup = window.open(
+    '/api/auth/patreon/login',
+    'patreon-oauth',
+    `width=${width},height=${height},left=${left},top=${top}`
+  );
+
+  if (!popup) {
+    return Promise.reject(new Error('Failed to open login popup'));
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(timer);
+        reject(new Error('Popup closed by user'));
+      }
+    }, 500);
+
+    function handleMessage(event: MessageEvent) {
+      if (event.source !== popup) return;
+      const data = event.data;
+      if (data?.type === 'patreon-auth') {
+        clearInterval(timer);
+        window.removeEventListener('message', handleMessage);
+        popup.close();
+        resolve({ token: data.token, user: data.user });
+      }
+    }
+
+    window.addEventListener('message', handleMessage);
+  });
+}

--- a/client/src/services/patreonAuth.ts
+++ b/client/src/services/patreonAuth.ts
@@ -15,40 +15,43 @@ export interface PatreonAuthResult {
  * Open a popup window to begin Patreon OAuth login. Resolves with token
  * and user info when authentication completes.
  */
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:3001";
+
 export function loginWithPatreon(): Promise<PatreonAuthResult> {
   const width = 600;
   const height = 700;
   const left = window.screenX + (window.outerWidth - width) / 2;
   const top = window.screenY + (window.outerHeight - height) / 2;
   const popup = window.open(
-    '/api/auth/patreon/login',
-    'patreon-oauth',
-    `width=${width},height=${height},left=${left},top=${top}`
+    `${API_BASE_URL}/api/auth/patreon/login`,
+    "patreon-oauth",
+    `width=${width},height=${height},left=${left},top=${top}`,
   );
 
   if (!popup) {
-    return Promise.reject(new Error('Failed to open login popup'));
+    return Promise.reject(new Error("Failed to open login popup"));
   }
 
   return new Promise((resolve, reject) => {
     const timer = setInterval(() => {
       if (popup.closed) {
         clearInterval(timer);
-        reject(new Error('Popup closed by user'));
+        reject(new Error("Popup closed by user"));
       }
     }, 500);
 
     function handleMessage(event: MessageEvent) {
       if (event.source !== popup) return;
       const data = event.data;
-      if (data?.type === 'patreon-auth') {
+      if (data?.type === "patreon-auth") {
         clearInterval(timer);
-        window.removeEventListener('message', handleMessage);
+        window.removeEventListener("message", handleMessage);
         popup.close();
         resolve({ token: data.token, user: data.user });
       }
     }
 
-    window.addEventListener('message', handleMessage);
+    window.addEventListener("message", handleMessage);
   });
 }

--- a/server/README.md
+++ b/server/README.md
@@ -74,3 +74,4 @@ npm run dev
 - `PATREON_CLIENT_ID` - Patreon OAuth client ID
 - `PATREON_CLIENT_SECRET` - Patreon OAuth client secret
 - `PATREON_REDIRECT_URI` - OAuth redirect URI used for Patreon authentication
+- `PATREON_USER_AGENT` - Custom User-Agent string sent to Patreon API

--- a/server/README.md
+++ b/server/README.md
@@ -39,6 +39,8 @@ npm run dev
 - `GET /api/game/session/:sessionId` - Validate a game session
 - `POST /api/game/score` - Submit a game score (requires valid session)
 - `GET /api/leaderboard` - Get the game leaderboard
+- `GET /api/auth/patreon/login` - Redirect to Patreon for OAuth login
+- `GET /api/auth/patreon/callback` - Handle OAuth callback and return user info
 
 ### Paid Endpoints (x402)
 
@@ -68,4 +70,7 @@ npm run dev
 - `NETWORK` - Blockchain network (use `base-sepolia` for testing)
 - `ADDRESS` - Your wallet address to receive game payments
 - `PORT` - Server port (default: 3001)
-- `GAME_PRICE` - Price per game in USD (default: 0.001) 
+- `GAME_PRICE` - Price per game in USD (default: 0.001)
+- `PATREON_CLIENT_ID` - Patreon OAuth client ID
+- `PATREON_CLIENT_SECRET` - Patreon OAuth client secret
+- `PATREON_REDIRECT_URI` - OAuth redirect URI used for Patreon authentication

--- a/server/patreon.ts
+++ b/server/patreon.ts
@@ -1,0 +1,94 @@
+export const PATREON_AUTH_URL = "https://www.patreon.com/oauth2/authorize";
+export const PATREON_TOKEN_URL = "https://www.patreon.com/api/oauth2/token";
+export const PATREON_IDENTITY_URL =
+  "https://www.patreon.com/api/oauth2/v2/identity?include=email";
+
+/**
+ * Generate the Patreon OAuth authorization URL for the user to approve access.
+ */
+export function getPatreonAuthUrl(state: string = "state") {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: process.env.PATREON_CLIENT_ID || "",
+    redirect_uri: process.env.PATREON_REDIRECT_URI || "",
+    scope: "identity identity[email]",
+    state,
+  });
+  return `${PATREON_AUTH_URL}?${params.toString()}`;
+}
+
+/**
+ * Exchange the OAuth authorization code for an access token.
+ */
+export async function getPatreonAccessToken(code: string) {
+  const params = new URLSearchParams();
+  params.append("code", code);
+  params.append("client_id", process.env.PATREON_CLIENT_ID || "");
+  params.append("client_secret", process.env.PATREON_CLIENT_SECRET || "");
+  params.append("redirect_uri", process.env.PATREON_REDIRECT_URI || "");
+  params.append("grant_type", "authorization_code");
+
+  const res = await fetch(PATREON_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to get token: ${res.status} ${res.statusText}`);
+  }
+
+  return (await res.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    scope: string;
+    token_type: string;
+  };
+}
+
+/**
+ * Refresh an expired access token using the refresh token.
+ */
+export async function refreshPatreonAccessToken(refreshToken: string) {
+  const params = new URLSearchParams();
+  params.append("refresh_token", refreshToken);
+  params.append("client_id", process.env.PATREON_CLIENT_ID || "");
+  params.append("client_secret", process.env.PATREON_CLIENT_SECRET || "");
+  params.append("grant_type", "refresh_token");
+
+  const res = await fetch(PATREON_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to refresh token: ${res.status} ${res.statusText}`);
+  }
+
+  return (await res.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    scope: string;
+    token_type: string;
+  };
+}
+
+/**
+ * Retrieve the user's Patreon profile information using the access token.
+ */
+export async function getPatreonUserInfo(token: string) {
+  const res = await fetch(PATREON_IDENTITY_URL, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch user info: ${res.status} ${res.statusText}`);
+  }
+
+  return res.json();
+}

--- a/server/patreon.ts
+++ b/server/patreon.ts
@@ -1,7 +1,11 @@
 export const PATREON_AUTH_URL = "https://www.patreon.com/oauth2/authorize";
 export const PATREON_TOKEN_URL = "https://www.patreon.com/api/oauth2/token";
 export const PATREON_IDENTITY_URL =
-  "https://www.patreon.com/api/oauth2/v2/identity?include=email";
+  "https://www.patreon.com/api/oauth2/v2/identity?fields%5Buser%5D=full_name,email,image_url,thumb_url";
+
+// User-Agent required by Patreon API docs
+export const PATREON_USER_AGENT =
+  process.env.PATREON_USER_AGENT || "Flappy x402 - Game Server";
 
 /**
  * Generate the Patreon OAuth authorization URL for the user to approve access.
@@ -30,7 +34,10 @@ export async function getPatreonAccessToken(code: string) {
 
   const res = await fetch(PATREON_TOKEN_URL, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": PATREON_USER_AGENT,
+    },
     body: params,
   });
 
@@ -59,7 +66,10 @@ export async function refreshPatreonAccessToken(refreshToken: string) {
 
   const res = await fetch(PATREON_TOKEN_URL, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": PATREON_USER_AGENT,
+    },
     body: params,
   });
 
@@ -83,6 +93,7 @@ export async function getPatreonUserInfo(token: string) {
   const res = await fetch(PATREON_IDENTITY_URL, {
     headers: {
       Authorization: `Bearer ${token}`,
+      "User-Agent": PATREON_USER_AGENT,
     },
   });
 


### PR DESCRIPTION
## Summary
- add Patreon OAuth endpoints to server
- expose Patreon login in game menu
- provide React context and login popup handling
- document Patreon environment variables and login steps

## Testing
- `npm run build` in server *(fails: cannot download packages)*
- `npm run build` in client *(fails: cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6864d8229bf0832687f3998a17e60fb8